### PR TITLE
C: Write unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ packages = ["src/small_project"]
 
 [tool.uv]
 managed = true
+
+[dependency-groups]
+dev = ["pytest>=8"]

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,37 @@
+from small_project import add, concat
+
+
+# Tests for add(a, b)
+
+def test_add_integers():
+    assert add(2, 3) == 5
+
+
+def test_add_floats():
+    assert add(1.5, 2.5) == 4.0
+
+
+def test_add_negative_numbers():
+    assert add(-4, 6) == 2
+
+
+def test_add_negative_result():
+    assert add(-10, 3) == -7
+
+
+# Tests for concat(a, b)
+
+def test_concat_two_nonempty_strings():
+    assert concat("hello", "world") == "helloworld"
+
+
+def test_concat_empty_left():
+    assert concat("", "world") == "world"
+
+
+def test_concat_empty_right():
+    assert concat("hello", "") == "hello"
+
+
+def test_concat_both_empty():
+    assert concat("", "") == ""


### PR DESCRIPTION
Closes #3

## Summary

This PR adds the unit test suite for the `small_project` library functions, targeting the `add(a, b)` and `concat(a, b)` signatures from `small_project`.

## Changes

- **`pyproject.toml`**: Added a `[dependency-groups]` table with `dev = ["pytest>=8"]` so that `uv run pytest` can resolve and run tests.
- **`tests/test_ops.py`**: New test module with 4 tests for `add` and 4 tests for `concat`.

### Test cases

**`add`**
- `test_add_integers` — basic integer addition (2 + 3 == 5)
- `test_add_floats` — floating-point addition (1.5 + 2.5 == 4.0)
- `test_add_negative_numbers` — one negative operand (-4 + 6 == 2)
- `test_add_negative_result` — negative result (-10 + 3 == -7)

**`concat`**
- `test_concat_two_nonempty_strings` — standard concatenation ("hello" + "world")
- `test_concat_empty_left` — empty string on the left ("" + "world")
- `test_concat_empty_right` — empty string on the right ("hello" + "")
- `test_concat_both_empty` — both sides empty ("" + "")

## Notes

Tests are written against the agreed signatures and can be developed in parallel with the implementation in #2. Once #2 is merged, `uv run pytest` should exit 0.